### PR TITLE
minor fix to allow parallel build

### DIFF
--- a/makefile
+++ b/makefile
@@ -50,7 +50,7 @@ SHIP = README FIXES $(SOURCE) ytab[ch].bak makefile  \
 a.out:	ytab.o $(OFILES)
 	$(CC) $(CFLAGS) ytab.o $(OFILES) $(ALLOC)  -lm
 
-$(OFILES):	awk.h ytab.h proto.h
+$(OFILES):	ytab.o awk.h ytab.h proto.h
 
 ytab.o:	awk.h proto.h awkgram.y
 	$(YACC) $(YFLAGS) awkgram.y


### PR DESCRIPTION
Add ytab.o as a dependency for $(OFILES) in the makefile, this allows to
build in parallel (make -j10 etc..)

Without this, the parallel jobs use the stock ytab.[ch] and proctab.c
files and the resulting nawk does not work.
